### PR TITLE
New JSON-like configuration support, alignment of names to Rust API

### DIFF
--- a/graph/cxx-single-runtime.yaml
+++ b/graph/cxx-single-runtime.yaml
@@ -3,6 +3,18 @@ flow: CxxCounter
 operators:
   - id: CxxCounter
     uri: file://./libcxx_operator.so
+    configuration:
+      map1:
+        foo: value
+        bar: value
+        baz: value
+      string1: some_value
+      empty:
+      list1:
+        - this
+        - is
+        - a
+        - list
     inputs:
       - id: tick
         type: unsigned char

--- a/graph/cxx-single-runtime.yaml
+++ b/graph/cxx-single-runtime.yaml
@@ -42,10 +42,10 @@ links:
       node: CxxSink
       input: count
 
-mapping:
-  - id: CxxSource
-    runtime: source
-  - id: CxxCounter
-    runtime: operator
-  - id: CxxSink
-    runtime: sink
+# mapping:
+#   - id: CxxSource
+#     runtime: source
+#   - id: CxxCounter
+#     runtime: operator
+#   - id: CxxSink
+#     runtime: sink

--- a/include/operator.hpp
+++ b/include/operator.hpp
@@ -27,7 +27,7 @@ public:
   std::uint8_t getCounter ();
 };
 
-std::unique_ptr<State> initialize(const rust::Vec<Configuration> &configuration);
+std::unique_ptr<State> initialize(rust::Str json_configuration);
 
 bool
 input_rule(Context &context, std::unique_ptr<State> &state,

--- a/include/operator.hpp
+++ b/include/operator.hpp
@@ -27,6 +27,7 @@ public:
   std::uint8_t getCounter ();
 };
 
+// Configuration is a JSON string, use any C++ JSON library to parse it.
 std::unique_ptr<State> initialize(rust::Str json_configuration);
 
 bool

--- a/include/sink.hpp
+++ b/include/sink.hpp
@@ -23,7 +23,8 @@ public:
   State();
 };
 
-std::unique_ptr<State> initialize(const rust::Vec<Configuration> &configuration);
+// Configuration is a JSON string, use any C++ JSON library to parse it.
+std::unique_ptr<State> initialize(rust::Str json_configuration);
 
 void
 run(Context &context, std::unique_ptr<State> &state, Input input);

--- a/include/source.hpp
+++ b/include/source.hpp
@@ -23,8 +23,8 @@ public:
   State();
 };
 
-std::unique_ptr<State>
-initialize(const rust::Vec<Configuration> &configuration);
+// Configuration is a JSON string, use any C++ JSON library to parse it.
+std::unique_ptr<State> initialize(rust::Str json_configuration);
 
 rust::Vec<unsigned char>
 run(Context &context, std::unique_ptr<State> &state);

--- a/src/operator.cpp
+++ b/src/operator.cpp
@@ -50,7 +50,6 @@ bool input_rule(Context &context, std::unique_ptr<State> &state,
 
 rust::Vec<Output> run(Context &context, std::unique_ptr<State> &state,
                       rust::Vec<Input> inputs) {
-  std::cout << "Hi!" << std::endl << std::flush;
   state->increaseCounter();
   rust::Vec<std::uint8_t> counter = {state->getCounter()};
   Output count{"count", counter};

--- a/src/operator.cpp
+++ b/src/operator.cpp
@@ -31,8 +31,9 @@ void State::increaseCounter(void) { counter += 1; }
 
 std::uint8_t State::getCounter(void) { return counter; }
 
-std::unique_ptr<State>
-initialize(const rust::Vec<Configuration> &configuration) {
+std::unique_ptr<State> initialize(rust::Str json_configuration) {
+  std::cout << "Configuration: " << std::endl;
+  std::cout << json_configuration.data() << '\0' << std::endl;
   return std::make_unique<State>();
 }
 

--- a/src/operator.cpp
+++ b/src/operator.cpp
@@ -20,6 +20,8 @@
 #include <string>
 #include <vector>
 
+#include <iostream>
+
 namespace zenoh {
 namespace flow {
 
@@ -47,6 +49,7 @@ bool input_rule(Context &context, std::unique_ptr<State> &state,
 
 rust::Vec<Output> run(Context &context, std::unique_ptr<State> &state,
                       rust::Vec<Input> inputs) {
+  std::cout << "Hi!" << std::endl << std::flush;
   state->increaseCounter();
   rust::Vec<std::uint8_t> counter = {state->getCounter()};
   Output count{"count", counter};

--- a/src/sink.cpp
+++ b/src/sink.cpp
@@ -20,8 +20,7 @@ namespace flow {
 
 State::State() {}
 
-std::unique_ptr<State>
-initialize(const rust::Vec<Configuration> &configuration) {
+std::unique_ptr<State> initialize(rust::Str json_configuration) {
   //
   // /!\ NOTE: `make_unique` requires "c++14"
   //

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -15,6 +15,9 @@
 #include <iostream>
 #include <memory>
 #include <ostream>
+#include <thread>
+#include <chrono>
+
 #include <source.hpp>
 
 namespace zenoh {
@@ -36,10 +39,12 @@ initialize(const rust::Vec<Configuration> &configuration)
 rust::Vec<byte_t>
 run(Context &context, std::unique_ptr<State> &state)
 {
-  std::string input;
+  //std::string input;
 
-  std::cout << "Press ENTER.";
-  std::getline(std::cin, input);
+  //std::cout << "Press ENTER.";
+  //std::getline(std::cin, input);
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
 
   rust::Vec<byte_t> tick = { 1 };
   return tick;

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -20,6 +20,9 @@
 
 #include <source.hpp>
 
+#include <chrono>
+#include <thread>
+
 namespace zenoh {
 namespace flow {
 
@@ -27,9 +30,7 @@ using byte_t = unsigned char;
 
 State::State() {}
 
-std::unique_ptr<State>
-initialize(const rust::Vec<Configuration> &configuration)
-{
+std::unique_ptr<State> initialize(rust::Str json_configuration) {
   //
   // /!\ NOTE: `make_unique` requires "c++14"
   //

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -12,7 +12,6 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 
-#include <iostream>
 #include <memory>
 #include <ostream>
 #include <thread>
@@ -40,12 +39,8 @@ std::unique_ptr<State> initialize(rust::Str json_configuration) {
 rust::Vec<byte_t>
 run(Context &context, std::unique_ptr<State> &state)
 {
-  //std::string input;
 
-  //std::cout << "Press ENTER.";
-  //std::getline(std::cin, input);
   std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-
 
   rust::Vec<byte_t> tick = { 1 };
   return tick;

--- a/vendor/operator/Cargo.toml
+++ b/vendor/operator/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 [dependencies]
 zenoh-flow = { git = "https://github.com/eclipse-zenoh/zenoh-flow.git", branch = "master" }
 cxx = "1.0"
+serde_json = "1.0"
 
 [lib]
 crate-type = ["staticlib"]

--- a/vendor/operator/src/lib.rs
+++ b/vendor/operator/src/lib.rs
@@ -32,6 +32,7 @@ pub mod ffi {
         pub value: String,
     }
 
+    #[derive(Debug)]
     pub struct Input {
         pub port_id: String,
         pub data: Vec<u8>,
@@ -39,16 +40,19 @@ pub mod ffi {
         pub e2d_deadline_miss: Vec<E2EDeadlineMiss>,
     }
 
+    #[derive(Debug)]
     pub struct Output {
         pub port_id: String,
         pub data: Vec<u8>,
     }
 
+    #[derive(Debug)]
     pub enum TokenStatus {
         Pending,
         Ready,
     }
 
+    #[derive(Debug)]
     pub enum TokenAction {
         Consume,
         Drop,
@@ -56,19 +60,22 @@ pub mod ffi {
         Wait,
     }
 
+    #[derive(Debug)]
     pub struct LocalDeadlineMiss {
         pub elapsed_ms: u64,
         pub deadline_duration_ms: u64,
         pub is_set: bool,
     }
 
+    #[derive(Debug)]
     pub struct E2EDeadlineMiss {
-        pub from: FromDescriptor,
-        pub to: ToDescriptor,
+        pub from: OutputDescriptor,
+        pub to: InputDescriptor,
         pub start: u64,
         pub end: u64,
     }
 
+    #[derive(Debug)]
     pub struct Token {
         pub status: TokenStatus,
         pub action: TokenAction,
@@ -77,12 +84,14 @@ pub mod ffi {
         pub timestamp: u64,
     }
 
-    pub struct FromDescriptor {
+    #[derive(Debug)]
+    pub struct OutputDescriptor {
         pub node: String,
         pub output: String,
     }
 
-    pub struct ToDescriptor {
+    #[derive(Debug)]
+    pub struct InputDescriptor {
         pub node: String,
         pub input: String,
     }
@@ -237,11 +246,11 @@ impl From<Option<LocalDeadlineMiss>> for ffi::LocalDeadlineMiss {
 
 impl From<&E2EDeadlineMiss> for ffi::E2EDeadlineMiss {
     fn from(e2d_deadline_miss: &E2EDeadlineMiss) -> Self {
-        let to = ffi::ToDescriptor {
+        let to = ffi::InputDescriptor {
             node: e2d_deadline_miss.to.node.as_ref().clone().into(),
             input: e2d_deadline_miss.to.input.as_ref().clone().into(),
         };
-        let from = ffi::FromDescriptor {
+        let from = ffi::OutputDescriptor {
             node: e2d_deadline_miss.from.node.as_ref().clone().into(),
             output: e2d_deadline_miss.from.output.as_ref().clone().into(),
         };
@@ -345,7 +354,6 @@ impl Operator for CxxOperator {
             .map(|(port_id, data_message)| ffi::Input::try_new(port_id, data_message))
             .collect();
         let cxx_inputs = result_cxx_inputs?;
-
         let cxx_outputs = {
             #[allow(unused_unsafe)]
             unsafe {

--- a/vendor/operator/src/lib.rs
+++ b/vendor/operator/src/lib.rs
@@ -27,11 +27,6 @@ pub mod ffi {
         pub mode: usize,
     }
 
-    // pub struct Configuration {
-    //     pub key: String,
-    //     pub value: String,
-    // }
-
     #[derive(Debug)]
     pub struct Input {
         pub port_id: String,
@@ -230,9 +225,9 @@ impl From<Option<LocalDeadlineMiss>> for ffi::LocalDeadlineMiss {
     fn from(deadline_miss: Option<LocalDeadlineMiss>) -> Self {
         match deadline_miss {
             Some(deadline_miss) => Self {
-                elapsed_ms: (deadline_miss.elapsed.as_secs_f64() * 1_000_000 as f64).floor() as u64,
-                deadline_duration_ms: (deadline_miss.deadline.as_secs_f64() * 1_000_000 as f64)
-                    .floor() as u64,
+                elapsed_ms: (deadline_miss.elapsed.as_secs_f64() * 1_000_000.0).floor() as u64,
+                deadline_duration_ms: (deadline_miss.deadline.as_secs_f64() * 1_000_000.0).floor()
+                    as u64,
                 is_set: true,
             },
             None => Self {
@@ -247,12 +242,12 @@ impl From<Option<LocalDeadlineMiss>> for ffi::LocalDeadlineMiss {
 impl From<&E2EDeadlineMiss> for ffi::E2EDeadlineMiss {
     fn from(e2d_deadline_miss: &E2EDeadlineMiss) -> Self {
         let to = ffi::InputDescriptor {
-            node: e2d_deadline_miss.to.node.as_ref().clone().into(),
-            input: e2d_deadline_miss.to.input.as_ref().clone().into(),
+            node: (*e2d_deadline_miss.to.node.as_ref()).into(),
+            input: (*e2d_deadline_miss.to.input.as_ref()).into(),
         };
         let from = ffi::OutputDescriptor {
-            node: e2d_deadline_miss.from.node.as_ref().clone().into(),
-            output: e2d_deadline_miss.from.output.as_ref().clone().into(),
+            node: (*e2d_deadline_miss.from.node.as_ref()).into(),
+            output: (*e2d_deadline_miss.from.output.as_ref()).into(),
         };
 
         Self {
@@ -276,22 +271,7 @@ impl Node for CxxOperator {
     fn initialize(&self, configuration: &Option<Configuration>) -> ZFResult<State> {
         let cxx_configuration = match configuration {
             Some(config) => match config.as_object() {
-                Some(config) => {
-                    let config = serde_json::to_string(config)?;
-                    config
-                    // let mut conf = vec![];
-                    // for (key, value) in config {
-                    //     let entry = ffi::Configuration {
-                    //         key: key.clone(),
-                    //         value: value
-                    //             .as_str()
-                    //             .ok_or_else(|| ZFError::GenericError)?
-                    //             .to_string(),
-                    //     };
-                    //     conf.push(entry);
-                    // }
-                    // conf
-                }
+                Some(config) => serde_json::to_string(config)?,
                 None => String::from("{}"),
             },
 

--- a/vendor/operator/src/lib.rs
+++ b/vendor/operator/src/lib.rs
@@ -27,10 +27,10 @@ pub mod ffi {
         pub mode: usize,
     }
 
-    pub struct Configuration {
-        pub key: String,
-        pub value: String,
-    }
+    // pub struct Configuration {
+    //     pub key: String,
+    //     pub value: String,
+    // }
 
     #[derive(Debug)]
     pub struct Input {
@@ -101,7 +101,7 @@ pub mod ffi {
 
         type State;
 
-        fn initialize(configuration: &Vec<Configuration>) -> UniquePtr<State>;
+        fn initialize(json_configuration: &str) -> UniquePtr<State>;
 
         fn input_rule(
             context: &mut Context,
@@ -277,23 +277,25 @@ impl Node for CxxOperator {
         let cxx_configuration = match configuration {
             Some(config) => match config.as_object() {
                 Some(config) => {
-                    let mut conf = vec![];
-                    for (key, value) in config {
-                        let entry = ffi::Configuration {
-                            key: key.clone(),
-                            value: value
-                                .as_str()
-                                .ok_or_else(|| ZFError::GenericError)?
-                                .to_string(),
-                        };
-                        conf.push(entry);
-                    }
-                    conf
+                    let config = serde_json::to_string(config)?;
+                    config
+                    // let mut conf = vec![];
+                    // for (key, value) in config {
+                    //     let entry = ffi::Configuration {
+                    //         key: key.clone(),
+                    //         value: value
+                    //             .as_str()
+                    //             .ok_or_else(|| ZFError::GenericError)?
+                    //             .to_string(),
+                    //     };
+                    //     conf.push(entry);
+                    // }
+                    // conf
                 }
-                None => vec![],
+                None => String::from("{}"),
             },
 
-            None => vec![],
+            None => String::from("{}"),
         };
 
         let state = {

--- a/vendor/sink/Cargo.toml
+++ b/vendor/sink/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 zenoh-flow = { git = "https://github.com/eclipse-zenoh/zenoh-flow.git", branch = "master" }
 cxx = "1.0"
 async-trait = "0.1.50"
+serde_json = "1.0"
 
 [lib]
 crate-type = ["staticlib"]

--- a/vendor/sink/src/lib.rs
+++ b/vendor/sink/src/lib.rs
@@ -16,8 +16,8 @@ use async_trait::async_trait;
 use cxx::UniquePtr;
 use std::{fmt::Debug, sync::Arc};
 use zenoh_flow::{
-    runtime::message::DataMessage, Configuration, Context, Node, Sink, State, ZFError, ZFResult,
-    ZFState, runtime::deadline::E2EDeadlineMiss
+    runtime::deadline::E2EDeadlineMiss, runtime::message::DataMessage, Configuration, Context,
+    Node, Sink, State, ZFError, ZFResult, ZFState,
 };
 
 extern crate zenoh_flow;
@@ -28,17 +28,19 @@ pub mod ffi {
         pub mode: usize,
     }
 
-    pub struct Configuration {
-        pub key: String,
-        pub value: String,
-    }
+    // pub struct Configuration {
+    //     pub key: String,
+    //     pub value: String,
+    // }
 
+    #[derive(Debug)]
     pub struct Input {
         pub data: Vec<u8>,
         pub timestamp: u64,
         pub e2d_deadline_miss: Vec<E2EDeadlineMiss>,
     }
 
+    #[derive(Debug)]
     pub struct E2EDeadlineMiss {
         pub from: OutputDescriptor,
         pub to: InputDescriptor,
@@ -46,11 +48,13 @@ pub mod ffi {
         pub end: u64,
     }
 
+    #[derive(Debug)]
     pub struct OutputDescriptor {
         pub node: String,
         pub output: String,
     }
 
+    #[derive(Debug)]
     pub struct InputDescriptor {
         pub node: String,
         pub input: String,
@@ -61,7 +65,7 @@ pub mod ffi {
 
         type State;
 
-        fn initialize(configuration: &Vec<Configuration>) -> UniquePtr<State>;
+        fn initialize(json_configuration: &str) -> UniquePtr<State>;
 
         fn run(context: &mut Context, state: &mut UniquePtr<State>, input: Input) -> Result<()>;
     }
@@ -106,12 +110,16 @@ impl ffi::Input {
     fn from_data_message(
         data_message: &mut zenoh_flow::runtime::message::DataMessage,
     ) -> ZFResult<Self> {
-        let data = data_message.get_inner_data().try_as_bytes()?.as_ref().clone();
+        let data = data_message
+            .get_inner_data()
+            .try_as_bytes()?
+            .as_ref()
+            .clone();
         let e2d_deadline_miss: Vec<ffi::E2EDeadlineMiss> = data_message
-        .get_missed_end_to_end_deadlines()
-        .iter()
-        .map(|e2e_deadline| e2e_deadline.into())
-        .collect();
+            .get_missed_end_to_end_deadlines()
+            .iter()
+            .map(|e2e_deadline| e2e_deadline.into())
+            .collect();
 
         Ok(Self {
             data,
@@ -154,23 +162,25 @@ impl Node for CxxSink {
         let cxx_configuration = match configuration {
             Some(config) => match config.as_object() {
                 Some(config) => {
-                    let mut conf = vec![];
-                    for (key, value) in config {
-                        let entry = ffi::Configuration {
-                            key: key.clone(),
-                            value: value
-                                .as_str()
-                                .ok_or_else(|| ZFError::GenericError)?
-                                .to_string(),
-                        };
-                        conf.push(entry);
-                    }
-                    conf
+                    let config = serde_json::to_string(config)?;
+                    config
+                    // let mut conf = vec![];
+                    // for (key, value) in config {
+                    //     let entry = ffi::Configuration {
+                    //         key: key.clone(),
+                    //         value: value
+                    //             .as_str()
+                    //             .ok_or_else(|| ZFError::GenericError)?
+                    //             .to_string(),
+                    //     };
+                    //     conf.push(entry);
+                    // }
+                    // conf
                 }
-                None => vec![],
+                None => String::from("{}"),
             },
 
-            None => vec![],
+            None => String::from("{}"),
         };
 
         let state = {
@@ -200,16 +210,16 @@ impl Sink for CxxSink {
         let cxx_input = ffi::Input::from_data_message(&mut input)?;
 
         {
-            let cxx_output_res : ZFResult<()> = async {
+            let cxx_output_res: ZFResult<()> = async {
                 #[allow(unused_unsafe)]
                 unsafe {
                     ffi::run(&mut cxx_context, &mut wrapper.state, cxx_input)
-                    .map_err(|_| ZFError::GenericError)
+                        .map_err(|_| ZFError::GenericError)
                 }
-            }.await;
+            }
+            .await;
             let cxx_output = cxx_output_res?;
             Ok(cxx_output)
-
         }
     }
 }

--- a/vendor/sink/src/lib.rs
+++ b/vendor/sink/src/lib.rs
@@ -28,11 +28,6 @@ pub mod ffi {
         pub mode: usize,
     }
 
-    // pub struct Configuration {
-    //     pub key: String,
-    //     pub value: String,
-    // }
-
     #[derive(Debug)]
     pub struct Input {
         pub data: Vec<u8>,
@@ -132,12 +127,12 @@ impl ffi::Input {
 impl From<&E2EDeadlineMiss> for ffi::E2EDeadlineMiss {
     fn from(e2d_deadline_miss: &E2EDeadlineMiss) -> Self {
         let to = ffi::InputDescriptor {
-            node: e2d_deadline_miss.to.node.as_ref().clone().into(),
-            input: e2d_deadline_miss.to.input.as_ref().clone().into(),
+            node: (*e2d_deadline_miss.to.node.as_ref()).into(),
+            input: (*e2d_deadline_miss.to.input.as_ref()).into(),
         };
         let from = ffi::OutputDescriptor {
-            node: e2d_deadline_miss.from.node.as_ref().clone().into(),
-            output: e2d_deadline_miss.from.output.as_ref().clone().into(),
+            node: (*e2d_deadline_miss.from.node.as_ref()).into(),
+            output: (*e2d_deadline_miss.from.output.as_ref()).into(),
         };
 
         Self {
@@ -161,22 +156,7 @@ impl Node for CxxSink {
     fn initialize(&self, configuration: &Option<Configuration>) -> ZFResult<State> {
         let cxx_configuration = match configuration {
             Some(config) => match config.as_object() {
-                Some(config) => {
-                    let config = serde_json::to_string(config)?;
-                    config
-                    // let mut conf = vec![];
-                    // for (key, value) in config {
-                    //     let entry = ffi::Configuration {
-                    //         key: key.clone(),
-                    //         value: value
-                    //             .as_str()
-                    //             .ok_or_else(|| ZFError::GenericError)?
-                    //             .to_string(),
-                    //     };
-                    //     conf.push(entry);
-                    // }
-                    // conf
-                }
+                Some(config) => serde_json::to_string(config)?,
                 None => String::from("{}"),
             },
 

--- a/vendor/source/Cargo.toml
+++ b/vendor/source/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 zenoh-flow = { git = "https://github.com/eclipse-zenoh/zenoh-flow.git", branch = "master" }
 cxx = "1.0"
 async-trait = "0.1.50"
+serde_json = "1.0"
 
 [lib]
 crate-type = ["staticlib"]

--- a/vendor/source/src/lib.rs
+++ b/vendor/source/src/lib.rs
@@ -25,11 +25,6 @@ pub mod ffi {
         pub mode: usize,
     }
 
-    // pub struct Configuration {
-    //     pub key: String,
-    //     pub value: String,
-    // }
-
     unsafe extern "C++" {
         include!("source.hpp");
 
@@ -88,22 +83,7 @@ impl Node for CxxSource {
     fn initialize(&self, configuration: &Option<Configuration>) -> ZFResult<State> {
         let cxx_configuration = match configuration {
             Some(config) => match config.as_object() {
-                Some(config) => {
-                    let config = serde_json::to_string(config)?;
-                    config
-                    // let mut conf = vec![];
-                    // for (key, value) in config {
-                    //     let entry = ffi::Configuration {
-                    //         key: key.clone(),
-                    //         value: value
-                    //             .as_str()
-                    //             .ok_or_else(|| ZFError::GenericError)?
-                    //             .to_string(),
-                    //     };
-                    //     conf.push(entry);
-                    // }
-                    // conf
-                }
+                Some(config) => serde_json::to_string(config)?,
                 None => String::from("{}"),
             },
 

--- a/vendor/source/src/lib.rs
+++ b/vendor/source/src/lib.rs
@@ -128,12 +128,13 @@ impl Source for CxxSource {
         let mut cxx_context = ffi::Context::from(context);
         let wrapper = dyn_state.try_get::<StateWrapper>()?;
 
-        let cxx_output = {
+        let cxx_output_res : ZFResult<Vec<u8>> = async {
             #[allow(unused_unsafe)]
             unsafe {
-                ffi::run(&mut cxx_context, &mut wrapper.state).map_err(|_| ZFError::GenericError)?
+                ffi::run(&mut cxx_context, &mut wrapper.state).map_err(|_| ZFError::GenericError)
             }
-        };
+        }.await;
+        let cxx_output = cxx_output_res?;
         Ok(Data::from_bytes(cxx_output))
     }
 }


### PR DESCRIPTION
This PR contains the implementation of the new `JSON-like` configuration.
The signature of the initialize function becomes: `std::unique_ptr<State> initialize(rust::Str json_configuration)` where json_configuration is a `rust::Str` that contains a `JSON` object. 
In order to parse it any C++ JSON library can be used.